### PR TITLE
Browser extension keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 # Patro
+
 HamroPatro has too much ads. We scrape their website, save data (date and tihis) in JSON and build alternative simpler ad-free mobile app and website out of it.
 
 ## API
+
 Meta at: <https://sumanchapai.github.io/patro/meta.json>\
 Year data available by replacing the word `meta` in the meta api with the year.
 For example: <https://sumanchapai.github.io/patro/2080.json>
 
 ## Chrome-extension
-You can get the Patro chrome extension at the chrome web store [here](https://chromewebstore.google.com/detail/patro/mnagbabdhfjkajadblahmbbddecinhml)
+
+You can get the Patro chrome extension at the chrome web store [here](https://chromewebstore.google.com/detail/patro/mnagbabdhfjkajadblahmbbddecinhml). The extension also supports various keyboard shortcuts for easier navigation which can be manually set/changed at `chrome://extensions/shortcuts`.
+
 <p align='center'>
-<img alt='Patro Chrome-extension' src="https://lh3.googleusercontent.com/fNbkcQY4EYpYh3prVBSccUbiuNxHAKpEssoWJj9OP6EZAtWtv95anq4CPuuBJpkNPB4dgN3uBLZ3D2cMg5zOk0w4kQs=s1280-w1280-h800">
+<img width="40%" height="350px" alt='Patro Chrome-extension' src="https://lh3.googleusercontent.com/fNbkcQY4EYpYh3prVBSccUbiuNxHAKpEssoWJj9OP6EZAtWtv95anq4CPuuBJpkNPB4dgN3uBLZ3D2cMg5zOk0w4kQs=s1280-w1280-h800">
+<img width="40%" height="350px" alt="image" src="https://github.com/sumanchapai/patro/assets/114323952/92e42d73-f7f0-4037-99d9-32d3f07eaa96">
 </p>
 
 ## CLI
-Install the CLI by running 
+
+Install the CLI by running
+
 ```bash
 go install github.com/sumanchapai/patro/cli/patro@latest
 ```
@@ -30,8 +37,7 @@ patro -3
 # Display the calendar for a given year, example patro 2080
 patro <year>
 
-# Display the calendar of a specific month of a specific year, example patro 7 2080 
+# Display the calendar of a specific month of a specific year, example patro 7 2080
 # Note that it's not patro <year> <month> to follow the convention of the cal command
 patro <month> <year>
 ```
-

--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -20,14 +20,14 @@
         }
         },
         "previous_month":{
-            "suggested_key": {"default": "Ctrl+J",
-                                "mac":"MacCtrl+J"
+            "suggested_key": {"default": "Ctrl+H",
+                                "mac":"MacCtrl+H"
         },
             "description": "Go to previous month in popup calendar"
         },
         "next_month":{
-            "suggested_key": {"default": "Ctrl+K",
-                                "mac":"MacCtrl+K"
+            "suggested_key": {"default": "Ctrl+L",
+                                "mac":"MacCtrl+L"
         },
             "description": "Go to next month in popup calendar"
         },

--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -2,7 +2,7 @@
     "name": "Patro",
     "description": "Minimalistic And Simple Nepali Calendar",
     "manifest_version": 3,
-    "version": "2.0.0",
+    "version": "1.2.1",
     "background": {"service_worker": "script/background.js"},
     "icons": {
         "16": "images/16.png",
@@ -38,11 +38,13 @@
             "description": "Show current day"
         },
         "previous_day":{
-         
             "description": "Go to previous day in popup calendar"
         },
         "next_day":{
             "description": "Go to next day in popup calendar"
+        },
+        "first_day_of_the_month":{
+            "description": "Go to the first day of the currently viewing month"
         }
     }
 }

--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -23,28 +23,28 @@
             "suggested_key": {"default": "Ctrl+H",
                                 "mac":"MacCtrl+H"
         },
-            "description": "Go to previous month in popup calendar"
+            "description": "View the previous month in calendar"
         },
         "next_month":{
             "suggested_key": {"default": "Ctrl+L",
                                 "mac":"MacCtrl+L"
         },
-            "description": "Go to next month in popup calendar"
+            "description": "View the next month in calendar"
         },
         "today":{
             "suggested_key": {"default": "Ctrl+T",
                                 "mac":"MacCtrl+T"
         },
-            "description": "Show current day"
+            "description": "Select the current day"
         },
         "previous_day":{
-            "description": "Go to previous day in popup calendar"
+            "description": "Select the previous day in calendar"
         },
         "next_day":{
-            "description": "Go to next day in popup calendar"
+            "description": "Select the next day in calendar"
         },
         "first_day_of_the_month":{
-            "description": "Go to the first day of the currently viewing month"
+            "description": "Select the first day of the currently viewing month"
         }
     }
 }

--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -3,6 +3,7 @@
     "description": "Minimalistic And Simple Nepali Calendar",
     "manifest_version": 3,
     "version": "1.1.1",
+    "background": {"service_worker": "script/background.js"},
     "icons": {
         "16": "images/16.png",
         "32": "images/32.png",
@@ -11,5 +12,31 @@
     },
     "action":{
         "default_popup": "index.html"
+    },
+    "commands":{
+        "_execute_action":{
+            "suggested_key": {"default": "Ctrl+P",
+                                "mac":"MacCtrl+P"
+        }
+        },
+        "previous_month":{
+            "suggested_key": {"default": "Ctrl+J",
+                                "mac":"MacCtrl+J"
+        },
+            "description": "Go to previous month in popup calendar"
+        },
+        "next_month":{
+            "suggested_key": {"default": "Ctrl+K",
+                                "mac":"MacCtrl+K"
+        },
+            "description": "Go to next month in popup calendar"
+        },
+        "today":{
+            "suggested_key": {"default": "Ctrl+T",
+                                "mac":"MacCtrl+T"
+        },
+            "description": "Show current day"
+        }
+
     }
 }

--- a/browser_extension/manifest.json
+++ b/browser_extension/manifest.json
@@ -2,7 +2,7 @@
     "name": "Patro",
     "description": "Minimalistic And Simple Nepali Calendar",
     "manifest_version": 3,
-    "version": "1.1.1",
+    "version": "2.0.0",
     "background": {"service_worker": "script/background.js"},
     "icons": {
         "16": "images/16.png",
@@ -36,7 +36,13 @@
                                 "mac":"MacCtrl+T"
         },
             "description": "Show current day"
+        },
+        "previous_day":{
+         
+            "description": "Go to previous day in popup calendar"
+        },
+        "next_day":{
+            "description": "Go to next day in popup calendar"
         }
-
     }
 }

--- a/browser_extension/script/background.js
+++ b/browser_extension/script/background.js
@@ -5,14 +5,14 @@ chrome.commands.onCommand.addListener(
     (command)=>{
         if (popupOpened && commandEnabled){
             if (command == 'previous_month'){
-                // TO DO
-                console.log('previous month command to execute');
+                // Execute command to show previous month
+                chrome.runtime.sendMessage({'command' : command})
             } else if (command == 'next_month'){
-                // TO DO
-                console.log('next month command to execute');
+                // Execute command to show next month
+                chrome.runtime.sendMessage({'command' : command})
             } else if (command == 'today'){
-                // TO DO
-                console.log('today command to be executed');
+                // Execute command to show current day, month, year
+                chrome.runtime.sendMessage({'command' : command})
             }
         }
     }
@@ -21,11 +21,11 @@ chrome.commands.onCommand.addListener(
 chrome.runtime.onConnect.addListener(
     (port)=>{
         if (port.name == 'popup'){
+            // popup has been opened
             popupOpened = true;
-            console.log("popup has been opened")
             port.onDisconnect.addListener(()=>{
                 popupOpened = false;
-                console.log("popup has been closed")
+                // popup has been closed
             })
         }
     }

--- a/browser_extension/script/background.js
+++ b/browser_extension/script/background.js
@@ -4,16 +4,7 @@ var popupOpened = false;
 chrome.commands.onCommand.addListener(
     (command)=>{
         if (popupOpened && commandEnabled){
-            if (command == 'previous_month'){
-                // Execute command to show previous month
                 chrome.runtime.sendMessage({'command' : command})
-            } else if (command == 'next_month'){
-                // Execute command to show next month
-                chrome.runtime.sendMessage({'command' : command})
-            } else if (command == 'today'){
-                // Execute command to show current day, month, year
-                chrome.runtime.sendMessage({'command' : command})
-            }
         }
     }
 )

--- a/browser_extension/script/background.js
+++ b/browser_extension/script/background.js
@@ -1,0 +1,32 @@
+var commandEnabled = true;
+var popupOpened = false;
+
+chrome.commands.onCommand.addListener(
+    (command)=>{
+        if (popupOpened && commandEnabled){
+            if (command == 'previous_month'){
+                // TO DO
+                console.log('previous month command to execute');
+            } else if (command == 'next_month'){
+                // TO DO
+                console.log('next month command to execute');
+            } else if (command == 'today'){
+                // TO DO
+                console.log('today command to be executed');
+            }
+        }
+    }
+)
+
+chrome.runtime.onConnect.addListener(
+    (port)=>{
+        if (port.name == 'popup'){
+            popupOpened = true;
+            console.log("popup has been opened")
+            port.onDisconnect.addListener(()=>{
+                popupOpened = false;
+                console.log("popup has been closed")
+            })
+        }
+    }
+)

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -1,6 +1,17 @@
 // Connect to background.js
 chrome.runtime.connect({name:"popup"});
 
+// Connect commands from background.js with the listener
+chrome.runtime.onMessage.addListener((message)=>{
+    if (message.command == 'previous_month'){
+        changeMonthAndYear("previous");
+    } else if (message.command == 'next_month'){
+        changeMonthAndYear("next");
+    } else if (message.command == 'today'){
+        show_today();
+    }
+})
+
 var monthsInEng = ["baishakh", "jestha", "asar", "shrawan",
         "bhadau", "aswin", "kartik", "mansir", 
         "poush", "magh", "falgun", "chaitra"];
@@ -244,6 +255,17 @@ function displayDayInformation(TdElement){
     highlightCurrentDay(false);
 }
 
+function show_today(){
+        changeMonthAndYear(null, true);
+        removeHighlightedDay();
+        let currentDateTdElement = document.getElementById(`${currentNepaliDate.getYear()}-${currentNepaliDate.getMonth()+1}-${currentNepaliDate.getDate()}`)
+        currentSelectedTdElement = currentDateTdElement;
+        currentSelectedTdElementID = currentDateTdElement.id;
+        // The argument first time is passed as true as
+        // we also want to display the current days info
+        // just like we would when someone opens the extension
+        highlightCurrentDay(true);
+}
 window.onload = function (){
 
     populateWeekdays(document.querySelector("thead"),weekNamesArray);
@@ -259,15 +281,7 @@ window.onload = function (){
     document.querySelector("#current_year").innerText = yearValue;
 
     document.querySelector("#today_button").addEventListener("click", ()=>{
-        changeMonthAndYear(null, true);
-        removeHighlightedDay();
-        let currentDateTdElement = document.getElementById(`${currentNepaliDate.getYear()}-${currentNepaliDate.getMonth()+1}-${currentNepaliDate.getDate()}`)
-        currentSelectedTdElement = currentDateTdElement;
-        currentSelectedTdElementID = currentDateTdElement.id;
-        // The argument first time is passed as true as
-        // we also want to display the current days info
-        // just like we would when someone opens the extension
-        highlightCurrentDay(true);
+            show_today();
         })
 
     createTrValues();

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -77,7 +77,15 @@ function resetTdValues(){
     }
 }
 
+function resetTrAttributes(){
+    let all_tr_elements = document.querySelectorAll("tbody>tr");
+    for (let tr_element of all_tr_elements){
+        tr_element.style.display = '';
+    }
+}
 function populateTrValues(monthValue){
+
+    resetTrAttributes();
     resetTdValues();
     let tbodyElement = document.querySelector("tbody");
     let allTdElements = tbodyElement.querySelectorAll("td");
@@ -104,6 +112,18 @@ function populateTrValues(monthValue){
         tdElement.setAttribute("id",allDays[currentDayIndex]["nep_date"]);
         currentDayIndex++;
         if (allDays.length == currentDayIndex){break;}
+    }
+
+    hide_tr_if_unoccupied();
+}
+
+function hide_tr_if_unoccupied(){
+
+    // CHeck if the last row is unoccupied, if it is unoccupied, hide it
+    let all_tr_elements = document.querySelectorAll("tbody>tr");
+    let last_tr_element = all_tr_elements[all_tr_elements.length - 1];
+    if (!last_tr_element.querySelector("td").hasAttribute("id")){
+        last_tr_element.style.display = 'none';
     }
 }
 
@@ -220,7 +240,7 @@ function populateWeekdays(element, arrayList){
 
 function createTrValues(){
     let tbody = document.querySelector("tbody");
-    for (let i=0; i < 5; i++){
+    for (let i=0; i < 6; i++){
         let trElement = document.createElement("tr");
         for (let i=0; i < 7; i++){
             let tdElement = document.createElement("td");

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -8,13 +8,13 @@ chrome.runtime.onMessage.addListener((message)=>{
     } else if (message.command == 'next_month'){
         changeMonthAndYear("next");
     } else if (message.command == 'today'){
-        show_today();
+        showToday();
     } else if (message.command == 'previous_day'){
-        show_previous_day();
+        showPreviousDay();
     } else if (message.command == 'next_day'){
-        show_next_day();
+        showNextDay();
     } else if (message.command == 'first_day_of_the_month'){
-        show_first_day();
+        showFirstDay();
     }
 })
 
@@ -78,9 +78,9 @@ function resetTdValues(){
 }
 
 function resetTrAttributes(){
-    let all_tr_elements = document.querySelectorAll("tbody>tr");
-    for (let tr_element of all_tr_elements){
-        tr_element.style.display = '';
+    let allTrElements = document.querySelectorAll("tbody>tr");
+    for (let trElement of allTrElements){
+        trElement.style.display = '';
     }
 }
 function populateTrValues(monthValue){
@@ -114,16 +114,16 @@ function populateTrValues(monthValue){
         if (allDays.length == currentDayIndex){break;}
     }
 
-    hide_tr_if_unoccupied();
+    hideTrIfUnoccupied();
 }
 
-function hide_tr_if_unoccupied(){
+function hideTrIfUnoccupied(){
 
     // CHeck if the last row is unoccupied, if it is unoccupied, hide it
-    let all_tr_elements = document.querySelectorAll("tbody>tr");
-    let last_tr_element = all_tr_elements[all_tr_elements.length - 1];
-    if (!last_tr_element.querySelector("td").hasAttribute("id")){
-        last_tr_element.style.display = 'none';
+    let allTrElements = document.querySelectorAll("tbody>tr");
+    let lastTrElement = allTrElements[allTrElements.length - 1];
+    if (!lastTrElement.querySelector("td").hasAttribute("id")){
+        lastTrElement.style.display = 'none';
     }
 }
 
@@ -180,7 +180,7 @@ function highlightCurrentDay(firstTime){
         console.log(error) ;
     }
 }
-function changeMonthAndYear(type, button_selected = false){
+function changeMonthAndYear(type, buttonSelected = false){
     
 
     let monthElement = document.querySelector("#current_month");
@@ -209,7 +209,7 @@ function changeMonthAndYear(type, button_selected = false){
         monthValue = monthsInEng[index+1];
         }
     
-    if (button_selected){
+    if (buttonSelected){
         monthValue = indexToMonth[currentNepaliDate.getMonth()];
         monthElement.innerText = monthValue;
         yearValue = currentNepaliDate.getYear();
@@ -281,7 +281,7 @@ function displayDayInformation(TdElement){
     highlightCurrentDay(false);
 }
 
-function show_today(){
+function showToday(){
         changeMonthAndYear(null, true);
         removeHighlightedDay();
         let currentDateTdElement = document.getElementById(`${currentNepaliDate.getYear()}-${currentNepaliDate.getMonth()+1}-${currentNepaliDate.getDate()}`)
@@ -293,7 +293,7 @@ function show_today(){
         highlightCurrentDay(true);
 }
 
-function change_calendar_to_required_month_and_year(year , monthIndex){
+function changeCalendarToRequiredMonthAndYear(year , monthIndex){
 
     let monthElement = document.querySelector("#current_month");
     let yearElement = document.querySelector("#current_year");
@@ -303,7 +303,7 @@ function change_calendar_to_required_month_and_year(year , monthIndex){
 
 }
 
-function show_next_day(){
+function showNextDay(){
 
     // use the currentSelectedTdElementID to get currently selected date values
     let selected_date_array = currentSelectedTdElementID.split('-');
@@ -311,7 +311,7 @@ function show_next_day(){
     let monthIndex = selected_date_array[1] - 1;
     let day = selected_date_array[2];
 
-    change_calendar_to_required_month_and_year(year, monthIndex)
+    changeCalendarToRequiredMonthAndYear(year, monthIndex)
 
     let nextDayValue = Number(day) + 1;
     let nextYearValue = Number(year);
@@ -343,14 +343,14 @@ function show_next_day(){
     }
 }
 
-function show_previous_day(){
+function showPreviousDay(){
 
     let selected_date_array = currentSelectedTdElementID.split('-');
     let year = selected_date_array[0];
     let monthIndex = selected_date_array[1] - 1;
     let day = selected_date_array[2];
 
-    change_calendar_to_required_month_and_year(year, monthIndex)
+    changeCalendarToRequiredMonthAndYear(year, monthIndex)
 
     let previousDayValue = Number(day) - 1;
     let previousYearValue = Number(year);
@@ -383,7 +383,7 @@ function show_previous_day(){
 
 }
 
-function show_first_day(){
+function showFirstDay(){
     let currentYearValue = Number(document.querySelector("#current_year").innerText);
     let monthName = capitalizeString(document.querySelector("#current_month").innerText.toLowerCase());
     let currentMonthIndex = monthToIndex[monthName];
@@ -408,7 +408,7 @@ window.onload = function (){
     document.querySelector("#current_year").innerText = yearValue;
 
     document.querySelector("#today_button").addEventListener("click", ()=>{
-            show_today();
+            showToday();
         })
 
     createTrValues();

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -1,3 +1,6 @@
+// Connect to background.js
+chrome.runtime.connect({name:"popup"});
+
 var monthsInEng = ["baishakh", "jestha", "asar", "shrawan",
         "bhadau", "aswin", "kartik", "mansir", 
         "poush", "magh", "falgun", "chaitra"];

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -9,6 +9,10 @@ chrome.runtime.onMessage.addListener((message)=>{
         changeMonthAndYear("next");
     } else if (message.command == 'today'){
         show_today();
+    } else if (message.command == 'previous_day'){
+        show_previous_day();
+    } else if (message.command == 'next_day'){
+        show_next_day();
     }
 })
 
@@ -214,7 +218,7 @@ function populateWeekdays(element, arrayList){
 
 function createTrValues(){
     let tbody = document.querySelector("tbody");
-    for (let i=0; i < 5; i++){
+    for (let i=0; i < 6; i++){
         let trElement = document.createElement("tr");
         for (let i=0; i < 7; i++){
             let tdElement = document.createElement("td");
@@ -266,6 +270,48 @@ function show_today(){
         // just like we would when someone opens the extension
         highlightCurrentDay(true);
 }
+
+function show_next_day(){
+    // use the currentSelectedTdElementID to get currently selected date values
+    let selected_date_array = currentSelectedTdElementID.split('-');
+    let year = selected_date_array[0];
+    let monthIndex = selected_date_array[1] - 1;
+    let day = selected_date_array[2];
+
+    let nextDayValue = Number(day) + 1;
+    let nextYearValue = Number(year);
+    let nextMonthValue = Number(monthIndex);
+    // Check if the next day value is valid
+    // If nextDayValue day falls in the same month, then no problem
+    // else, it will be the first day of the next month
+    if (nextDayValue > ALL_YEARS_DATA[year]['months'][indexToMonth[monthIndex]]["days"].length){
+        // not possible to be in the same month
+        // increase monthvalue and set day to 1
+        nextDayValue = 1;
+        nextMonthValue++;
+        if (nextMonthValue > 11){
+            // the next day is the new year day
+            nextMonthValue = 0;
+            nextYearValue++;
+        }
+    }
+    
+    // simulate as if someone clicked that day
+    let elementID = `${nextYearValue}-${nextMonthValue+1}-${nextDayValue}`
+
+    if (nextDayValue != 1){
+    displayDayInformation(document.getElementById(elementID));
+    } else {
+    // But we need to change calendar month if needed
+    changeMonthAndYear('next');
+    displayDayInformation(document.getElementById(elementID));
+    }
+}
+
+function show_previous_day(){
+
+}
+
 window.onload = function (){
 
     populateWeekdays(document.querySelector("thead"),weekNamesArray);

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -220,7 +220,7 @@ function populateWeekdays(element, arrayList){
 
 function createTrValues(){
     let tbody = document.querySelector("tbody");
-    for (let i=0; i < 6; i++){
+    for (let i=0; i < 5; i++){
         let trElement = document.createElement("tr");
         for (let i=0; i < 7; i++){
             let tdElement = document.createElement("td");

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -273,6 +273,7 @@ function show_today(){
 
 function show_next_day(){
     // use the currentSelectedTdElementID to get currently selected date values
+    
     let selected_date_array = currentSelectedTdElementID.split('-');
     let year = selected_date_array[0];
     let monthIndex = selected_date_array[1] - 1;
@@ -309,6 +310,40 @@ function show_next_day(){
 }
 
 function show_previous_day(){
+
+    let selected_date_array = currentSelectedTdElementID.split('-');
+    let year = selected_date_array[0];
+    let monthIndex = selected_date_array[1] - 1;
+    let day = selected_date_array[2];
+
+    let previousDayValue = Number(day) - 1;
+    let previousYearValue = Number(year);
+    let previousMonthValue = Number(monthIndex);
+
+    // Check if the previous day value is valid
+    // invalid if day value is 0
+    if (previousDayValue < 1){
+        // not possible to be in the same month
+        // decrease monthvalue and set day to last day of previous month
+        previousMonthValue--;
+        if (previousMonthValue < 0){
+            // the next day is the new year day
+            previousMonthValue = 11;
+            previousYearValue--;
+        }
+        previousDayValue = ALL_YEARS_DATA[previousYearValue]['months'][indexToMonth[previousMonthValue]]["days"].length;
+    }
+    
+    // simulate as if someone clicked that day
+    let elementID = `${previousYearValue}-${previousMonthValue+1}-${previousDayValue}`
+
+    if (monthIndex == previousMonthValue && year == previousYearValue){
+    displayDayInformation(document.getElementById(elementID));
+    } else {
+    // But we need to change calendar month if needed
+    changeMonthAndYear('previous');
+    displayDayInformation(document.getElementById(elementID));
+    }
 
 }
 

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -13,6 +13,8 @@ chrome.runtime.onMessage.addListener((message)=>{
         show_previous_day();
     } else if (message.command == 'next_day'){
         show_next_day();
+    } else if (message.command == 'first_day_of_the_month'){
+        show_first_day();
     }
 })
 
@@ -359,6 +361,16 @@ function show_previous_day(){
     displayDayInformation(document.getElementById(elementID));
     }
 
+}
+
+function show_first_day(){
+    let currentYearValue = Number(document.querySelector("#current_year").innerText);
+    let monthName = capitalizeString(document.querySelector("#current_month").innerText.toLowerCase());
+    let currentMonthIndex = monthToIndex[monthName];
+
+    let elementID = `${currentYearValue}-${currentMonthIndex+1}-${1}`
+    console.log(elementID);
+    displayDayInformation(document.getElementById(elementID));
 }
 
 window.onload = function (){

--- a/browser_extension/script/script.js
+++ b/browser_extension/script/script.js
@@ -271,13 +271,25 @@ function show_today(){
         highlightCurrentDay(true);
 }
 
+function change_calendar_to_required_month_and_year(year , monthIndex){
+
+    let monthElement = document.querySelector("#current_month");
+    let yearElement = document.querySelector("#current_year");
+    yearElement.innerText = year
+    monthElement.innerText = indexToMonth[monthIndex];
+    showCalendar(monthIndex, year);
+
+}
+
 function show_next_day(){
+
     // use the currentSelectedTdElementID to get currently selected date values
-    
     let selected_date_array = currentSelectedTdElementID.split('-');
     let year = selected_date_array[0];
     let monthIndex = selected_date_array[1] - 1;
     let day = selected_date_array[2];
+
+    change_calendar_to_required_month_and_year(year, monthIndex)
 
     let nextDayValue = Number(day) + 1;
     let nextYearValue = Number(year);
@@ -315,6 +327,8 @@ function show_previous_day(){
     let year = selected_date_array[0];
     let monthIndex = selected_date_array[1] - 1;
     let day = selected_date_array[2];
+
+    change_calendar_to_required_month_and_year(year, monthIndex)
 
     let previousDayValue = Number(day) - 1;
     let previousYearValue = Number(year);


### PR DESCRIPTION
Add keyboard shortcuts to open/close and navigate around the patro chrome extension. 

A background.js service worker has been added which listens for keyboard shortcut(command) inputs as for our extension and sends message to the script.js for the popup to execute different functions.

It is important to note that the shortcuts are enabled only when the popup is open except for the command to open the extension itself. 

